### PR TITLE
🧑‍🚒 Fix snapshot version task

### DIFF
--- a/buildSrc/src/main/kotlin/studio/lunabee/library/SnapshotTask.kt
+++ b/buildSrc/src/main/kotlin/studio/lunabee/library/SnapshotTask.kt
@@ -28,8 +28,8 @@ import org.gradle.api.tasks.TaskAction
 abstract class SnapshotTask : DefaultTask() {
     @TaskAction
     fun setSnapshotVersion() {
-        val file = File(project.name + "/build.gradle.kts")
-        val newContents = file.readText().replace(Regex("version = \"[^\"]*")) { matchResult ->
+        val file = File(project.rootDir.path + "/buildSrc/src/main/kotlin/AndroidConfig.kt")
+        val newContents = file.readText().replace(Regex("${project.properties["libName"]}: String = \"[^\"]*")) { matchResult ->
             "${matchResult.value}-${project.properties["counter"]}-SNAPSHOT"
         }
         file.writeText(newContents)


### PR DESCRIPTION
## 📜 Description
Versions were extracted to `AndroidConfig.kt` file, making `SnapshotTask` useless (but not failing).
Version was not updated with `buildCounter-SNAPSHOT`, causing libraries to never be upload to snapshot repositories.

## 💡 Motivation and Context
Making snapshot upload work again from CI.

## 💚 How did you test it?
Run a Job from TeamCity from this branch and see upload confirmation in snapshot repositories 👇 
https://s01.oss.sonatype.org/content/repositories/snapshots/studio/lunabee/compose/
Also check that the pom.xml has versions correctly set (and no `_` instead of real version).

Check that no release was sent to release repositories 👇 
https://s01.oss.sonatype.org/content/repositories/releases/studio/lunabee/compose/

## 📝 Checklist
* [x] I compiled before submitting the PR
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`

## 🔮 Next steps
Re-check release with master on https://s01.oss.sonatype.org/content/repositories/releases/studio/lunabee/compose/
