### PR TITLE
Show seed color and its tones

### DIFF
--- a/app/src/main/java/studio/lunabee/compose/material3/theme/ThemeScreen.kt
+++ b/app/src/main/java/studio/lunabee/compose/material3/theme/ThemeScreen.kt
@@ -102,10 +102,10 @@ fun ThemeScreen(
                     },
                 )
             }
-        ) {
+        ) { paddingValues ->
             Column(
                 modifier = Modifier
-                    .padding(paddingValues = it),
+                    .padding(paddingValues = paddingValues),
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -125,10 +125,30 @@ fun ThemeScreen(
 
                     Spacer(modifier = Modifier.width(16.dp))
 
+                    customColor?.let {
+                        BoxWithColorHex(
+                            color = customColor,
+                            modifier = Modifier.padding(top = 8.dp)
+                        )
+
+                        Spacer(modifier = Modifier.width(16.dp))
+                    }
+
+
                     BoxWithColorHex(
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(top = 8.dp)
                     )
+                }
+
+                val colorMap = mutableListOf<Pair<String, Color>>()
+                customColor?.let { colorMap += "Custom seed" to customColor }
+                ColorScheme::class.java.declaredFields.mapNotNullTo(colorMap) { field ->
+                    field.isAccessible = true
+                    @Suppress("unchecked_cast")
+                    val color = (field.get(MaterialTheme.colorScheme) as? State<Color>)?.value
+                    val colorName = field.name.substringBefore('$')
+                    color?.let { colorName to color }
                 }
 
                 LazyColumn(
@@ -142,14 +162,10 @@ fun ThemeScreen(
                                 .padding(horizontal = 16.dp),
                         )
                     }
-                    items(
-                        items = ColorScheme::class.java.declaredFields,
-                    ) { field ->
-                        field.isAccessible = true
-                        @Suppress("unchecked_cast")
-                        val color = (field.get(MaterialTheme.colorScheme) as? State<Color>)?.value
 
-                        val colorName = field.name.substringBefore('$')
+                    items(
+                        items = colorMap,
+                    ) { (colorName, color) ->
                         Text(
                             text = colorName,
                             modifier = Modifier
@@ -157,32 +173,30 @@ fun ThemeScreen(
                             style = MaterialTheme.typography.titleLarge
                         )
 
-                        color?.let {
-                            LazyRow {
+                        LazyRow {
+                            item {
+                                BoxWithColorHex(
+                                    color = color,
+                                    modifier = Modifier
+                                        .wrapContentWidth()
+                                        .padding(all = 8.dp)
+                                )
+                            }
+
+                            for (i in 5 until 100 step 5) {
                                 item {
+                                    val tone = LbcThemeUtilities.getToneForColor(color = color, tone = i)
+
                                     BoxWithColorHex(
-                                        color = color,
+                                        color = tone,
                                         modifier = Modifier
                                             .wrapContentWidth()
                                             .padding(all = 8.dp)
-                                    )
-                                }
-
-                                for (i in 5 until 100 step 5) {
-                                    item {
-                                        val tone = LbcThemeUtilities.getToneForColor(color = color, tone = i)
-
-                                        BoxWithColorHex(
-                                            color = tone,
-                                            modifier = Modifier
-                                                .wrapContentWidth()
-                                                .padding(all = 8.dp)
-                                        ) {
-                                            Text(
-                                                text = (100 - i).toString(),
-                                                color = if (tone.luminance() >= 0.5) Color.Black else Color.White,
-                                            )
-                                        }
+                                    ) {
+                                        Text(
+                                            text = (100 - i).toString(),
+                                            color = if (tone.luminance() >= 0.5) Color.Black else Color.White,
+                                        )
                                     }
                                 }
                             }

--- a/app/src/main/java/studio/lunabee/compose/material3/theme/ThemeScreen.kt
+++ b/app/src/main/java/studio/lunabee/compose/material3/theme/ThemeScreen.kt
@@ -134,7 +134,6 @@ fun ThemeScreen(
                         Spacer(modifier = Modifier.width(16.dp))
                     }
 
-
                     BoxWithColorHex(
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(top = 8.dp)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -73,7 +73,7 @@
     <!-- Material3Screen -->
     <string name="material3_theme_title">"Theme"</string>
     <string name="material3_theme_subtitle">"Méthode utiles pour générer des couleurs dynamiquement"</string>
-    <string name="material3_theme_primary_explanation">"La couleur affichée sur la droite est la couleur primary générée à partir de la couleur que vous avez entré"</string>
+    <string name="material3_theme_primary_explanation">"La couleur affichée la plus à droite est la couleur primary générée à partir de la couleur source que vous avez entré"</string>
 
     <!-- ThemeScreen -->
     <string name="material3_theme_color_placeholder">"#EEFF00"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,7 +75,7 @@
     <!-- Material3Screen -->
     <string name="material3_theme_title">"Theme"</string>
     <string name="material3_theme_subtitle">"Utilities method to generate dynamic color"</string>
-    <string name="material3_theme_primary_explanation">Color displayed at the end is the primary color generated based on the color you enter.</string>
+    <string name="material3_theme_primary_explanation">Color displayed at the end is the primary color generated based on the seed color you enter.</string>
 
     <!-- ThemeScreen -->
     <string name="material3_theme_color_placeholder">"#EEFF00"</string>


### PR DESCRIPTION
## 📜 Description
- Also display the seed color entered with its tones

## 💡 Motivation and Context
- Preview colors obtained by calling `LbcThemeUtilities.getToneForColor(color = MaterialTheme.colorScheme.primary, tone = XX)`

## 💚 How did you test it?
- Enter a color hex

## 📝 Checklist
* [x] I compiled before submitting the PR
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`

## 📸 Screenshots / GIFs
![image](https://user-images.githubusercontent.com/45555889/199536528-9063cbd5-72cf-40d1-820d-679cc7c845d2.png)