### PR TITLE
Use minSdk 21

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -30,6 +30,6 @@ object Modules {
 object BuildConfigs {
     const val lunabeeCompose: String = "1.0.0"
     const val compileSdk: Int = 33
-    const val minSdk: Int = 23
+    const val minSdk: Int = 21
     const val targetSdk: Int = 33
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -24,4 +24,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2022 Lunabee Studio
+# Copyright ï¿½ 2022 Lunabee Studio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 #### suppress inspection "SpellCheckingInspection" for whole file
 #### suppress inspection "UnusedProperty" for whole file
 
-plugin.android=7.4.1
+plugin.android=7.4.2
 ## # available=8.0.0-alpha01
 ## # available=8.0.0-alpha02
 ## # available=8.0.0-alpha03
@@ -43,12 +43,15 @@ plugin.android=7.4.1
 ## # available=8.0.0-beta01
 ## # available=8.0.0-beta02
 ## # available=8.0.0-beta03
+## # available=8.0.0-beta04
 ## # available=8.1.0-alpha01
 ## # available=8.1.0-alpha02
 ## # available=8.1.0-alpha03
 ## # available=8.1.0-alpha04
 ## # available=8.1.0-alpha05
 ## # available=8.1.0-alpha06
+## # available=8.1.0-alpha07
+## # available=8.1.0-alpha08
 
 plugin.io.gitlab.arturbosch.detekt=1.22.0
 
@@ -83,6 +86,7 @@ version.androidx.core=1.9.0
 version.androidx.navigation-compose=2.6.0-alpha06
 
 version.androidx.test.runner=1.5.2
+##               # available=1.5.3-alpha01
 
 version.google.accompanist=0.29.1-alpha
 


### PR DESCRIPTION
## 📜 Description
- Use minSdk 21

## 💡 Motivation and Context
- Some module in oneSafe 6 are sdk 21 to be used by oneSafe 5. These modules have dependencies on test module.

## 💚 How did you test it?
- Build & run demo on device API 21

## 📝 Checklist
* [x] I compiled before submitting the PR
* [x] I reviewed the submitted code
* [ ] I launched `./gradlew detekt`

## 🔮 Next steps

## 📸 Screenshots / GIFs
