### PR TITLE
Update LbcTextSpec

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,6 +15,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - New module for Android Compose testing.
 
+### LbcCore
+- Add a method to get string with context in `LbcTextSpec`
+
 ### All
 
 - Update to last stable version of Jetpack Compose.

--- a/lbccore/src/androidTest/java/studio/lunabee/compose/core/LbcTextSpecTest.kt
+++ b/lbccore/src/androidTest/java/studio/lunabee/compose/core/LbcTextSpecTest.kt
@@ -20,6 +20,7 @@
  */
 package studio.lunabee.compose.core
 
+import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -34,12 +35,16 @@ class LbcTextSpecTest {
     val composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<ComponentActivity>, ComponentActivity> =
         createAndroidComposeRule()
 
+    val context: Context
+        get() = composeTestRule.activity.baseContext
+
     @Test
     fun raw_test() {
         val expected = "test"
         val textSpec = LbcTextSpec.Raw(value = expected)
         composeTestRule.setContent {
             assertEquals(expected, textSpec.string)
+            assertEquals(expected, textSpec.string(context))
             assertEquals(AnnotatedString(expected), textSpec.annotated)
         }
     }
@@ -52,6 +57,7 @@ class LbcTextSpecTest {
         val textSpec = LbcTextSpec.Raw(value = test, param)
         composeTestRule.setContent {
             assertEquals(expected, textSpec.string)
+            assertEquals(expected, textSpec.string(context))
             assertEquals(AnnotatedString(expected), textSpec.annotated)
         }
     }
@@ -63,6 +69,7 @@ class LbcTextSpecTest {
         composeTestRule.setContent {
             assertEquals(expected, textSpec.annotated)
             assertEquals(expected.text, textSpec.string)
+            assertEquals(expected.text, textSpec.string(context))
         }
     }
 
@@ -80,7 +87,9 @@ class LbcTextSpecTest {
 
         composeTestRule.setContent {
             assertEquals(expectedTest, actualTest.string)
+            assertEquals(expectedTest, actualTest.string(context))
             assertEquals(expectedTestArgs, actualTestArgs.string)
+            assertEquals(expectedTestArgs, actualTestArgs.string(context))
 
             assertEquals(AnnotatedString(expectedTest), actualTest.annotated)
             assertEquals(AnnotatedString(expectedTestArgs), actualTestArgs.annotated)
@@ -102,6 +111,7 @@ class LbcTextSpecTest {
 
         composeTestRule.setContent {
             assertEquals(expectedTestArgs, actualTestArgs.string)
+            assertEquals(expectedTestArgs, actualTestArgs.string(context))
             assertEquals(AnnotatedString(expectedTestArgs), actualTestArgs.annotated)
         }
     }
@@ -122,7 +132,9 @@ class LbcTextSpecTest {
 
         composeTestRule.setContent {
             assertEquals(expectedTestOne, actualTestOne.string)
+            assertEquals(expectedTestOne, actualTestOne.string(context))
             assertEquals(expectedTestMany, actualTestMany.string)
+            assertEquals(expectedTestMany, actualTestMany.string(context))
 
             assertEquals(AnnotatedString(expectedTestOne), actualTestOne.annotated)
             assertEquals(AnnotatedString(expectedTestMany), actualTestMany.annotated)

--- a/lbccore/src/main/java/studio/lunabee/compose/core/LbcTextSpec.kt
+++ b/lbccore/src/main/java/studio/lunabee/compose/core/LbcTextSpec.kt
@@ -20,6 +20,7 @@
  */
 package studio.lunabee.compose.core
 
+import android.content.Context
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
@@ -40,6 +41,8 @@ sealed class LbcTextSpec {
     abstract val string: String
         @ReadOnlyComposable @Composable
         get
+
+    abstract fun string(context: Context): String
 
     @Composable
     @ReadOnlyComposable
@@ -75,6 +78,14 @@ sealed class LbcTextSpec {
                 value.format(*args.resolveArgs())
             }
 
+        override fun string(context: Context): String {
+            return if (args.isEmpty()) {
+                value
+            } else {
+                value.format(args)
+            }
+        }
+
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
@@ -105,6 +116,8 @@ sealed class LbcTextSpec {
             @Composable
             @ReadOnlyComposable
             get() = value.text
+
+        override fun string(context: Context): String = value.text
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -141,6 +154,10 @@ sealed class LbcTextSpec {
             @ReadOnlyComposable
             @Suppress("SpreadOperator")
             get() = stringResource(id, *args.resolveArgs())
+
+        override fun string(context: Context): String {
+            return context.getString(id, args)
+        }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -179,6 +196,10 @@ sealed class LbcTextSpec {
             @ReadOnlyComposable
             @Suppress("SpreadOperator")
             get() = pluralStringResource(id, count, *args.resolveArgs())
+
+        override fun string(context: Context): String {
+            return context.resources.getQuantityString(id, count, args)
+        }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/lbccore/src/main/java/studio/lunabee/compose/core/LbcTextSpec.kt
+++ b/lbccore/src/main/java/studio/lunabee/compose/core/LbcTextSpec.kt
@@ -57,6 +57,17 @@ sealed class LbcTextSpec {
         }
     }
 
+    protected fun Array<out Any>.resolveArgsContext(context: Context): Array<out Any> {
+        return Array(this.size) { idx ->
+            val entry = this[idx]
+            if (entry is LbcTextSpec) {
+                entry.string(context) // marked as compile error due to Java(?)
+            } else {
+                this[idx]
+            }
+        }
+    }
+
     class Raw(private val value: String, private vararg val args: Any) : LbcTextSpec() {
         override val annotated: AnnotatedString
             @Composable
@@ -82,7 +93,8 @@ sealed class LbcTextSpec {
             return if (args.isEmpty()) {
                 value
             } else {
-                value.format(args)
+                @Suppress("SpreadOperator")
+                value.format(*args.resolveArgsContext(context))
             }
         }
 
@@ -156,7 +168,8 @@ sealed class LbcTextSpec {
             get() = stringResource(id, *args.resolveArgs())
 
         override fun string(context: Context): String {
-            return context.getString(id, args)
+            @Suppress("SpreadOperator")
+            return context.getString(id, *args.resolveArgsContext(context))
         }
 
         override fun equals(other: Any?): Boolean {
@@ -198,7 +211,8 @@ sealed class LbcTextSpec {
             get() = pluralStringResource(id, count, *args.resolveArgs())
 
         override fun string(context: Context): String {
-            return context.resources.getQuantityString(id, count, args)
+            @Suppress("SpreadOperator")
+            return context.resources.getQuantityString(id, count, *args.resolveArgsContext(context))
         }
 
         override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
## 📜 Description
☞ App `string(context)` in `LbcTextSpec` to get string without a composable function

## 💡 Motivation and Context
Some operation can require `LbcTextSpec`.string but can not be done in @Composable.

## 💚 How did you test it?

## 📝 Checklist
* [ ] I compiled before submitting the PR
* [ ] I reviewed the submitted code
* [ ] I launched `./gradlew detekt`

## 🔮 Next steps

## 📸 Screenshots / GIFs
