### PR TITLE
Add StringByNameResource to LbcTextSpec

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -17,6 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### LbcCore
 - Add a method to get string with context in `LbcTextSpec`
+- Add a sealed class of `LbcTextSpec` to find string in resource by name
 
 ### All
 

--- a/lbccore/src/androidTest/java/studio/lunabee/compose/core/LbcTextSpecTest.kt
+++ b/lbccore/src/androidTest/java/studio/lunabee/compose/core/LbcTextSpecTest.kt
@@ -35,7 +35,7 @@ class LbcTextSpecTest {
     val composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<ComponentActivity>, ComponentActivity> =
         createAndroidComposeRule()
 
-    val context: Context
+    private val context: Context
         get() = composeTestRule.activity.baseContext
 
     @Test
@@ -138,6 +138,50 @@ class LbcTextSpecTest {
 
             assertEquals(AnnotatedString(expectedTestOne), actualTestOne.annotated)
             assertEquals(AnnotatedString(expectedTestMany), actualTestMany.annotated)
+        }
+    }
+
+    @Test
+    fun stringByName_test() {
+        val expectedTest = composeTestRule.activity.getString(studio.lunabee.compose.core.test.R.string.test)
+        val actualTest = LbcTextSpec.StringByNameResource(name = "test", fallbackId = -1)
+        val actualFallbackTest = LbcTextSpec.StringByNameResource(
+            name = "does_not_exist",
+            fallbackId = studio.lunabee.compose.core.test.R.string.test,
+        )
+
+        val stringParam = "foo"
+        val intParam = 123
+        val expectedTestArgs = composeTestRule
+            .activity
+            .getString(studio.lunabee.compose.core.test.R.string.test_args, stringParam, intParam)
+        val actualTestArgs = LbcTextSpec.StringByNameResource(
+            name = "test_args",
+            fallbackId = -1,
+            stringParam,
+            intParam,
+        )
+        val actualTestFallbackArgs = LbcTextSpec.StringByNameResource(
+            name = "does_not_exist",
+            fallbackId = studio.lunabee.compose.core.test.R.string.test_args,
+            stringParam,
+            intParam,
+        )
+
+        composeTestRule.setContent {
+            assertEquals(expectedTest, actualTest.string)
+            assertEquals(expectedTest, actualTest.string(context))
+            assertEquals(expectedTest, actualFallbackTest.string)
+            assertEquals(expectedTest, actualFallbackTest.string(context))
+            assertEquals(expectedTestArgs, actualTestArgs.string)
+            assertEquals(expectedTestArgs, actualTestArgs.string(context))
+            assertEquals(expectedTestArgs, actualTestFallbackArgs.string)
+            assertEquals(expectedTestArgs, actualTestFallbackArgs.string(context))
+
+            assertEquals(AnnotatedString(expectedTest), actualTest.annotated)
+            assertEquals(AnnotatedString(expectedTest), actualFallbackTest.annotated)
+            assertEquals(AnnotatedString(expectedTestArgs), actualTestArgs.annotated)
+            assertEquals(AnnotatedString(expectedTestArgs), actualTestFallbackArgs.annotated)
         }
     }
 }


### PR DESCRIPTION
## 📜 Description

Add `StringByNameResource` class to find string from resource and fallback to known string

## 💡 Motivation and Context

Needed in Immortal to get server error from resource
i.e. Error from WS `signin` with status `WRONG_CREDENTIAL` will make us fetch the string resource `server_error_signin_WRONG_CREDENTIAL_message` if we don't find the string, we fallback to an id that we are sure exist in the resources

## 💚 How did you test it?

Unit test + PR in progress in Immortal

## 📝 Checklist
* [x] I compiled before submitting the PR
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`

## 📸 Screenshots / GIFs
<img width="570" alt="Capture d’écran, le 2023-04-26 à 16 22 17" src="https://user-images.githubusercontent.com/13695454/234605858-1da5d839-8db2-43ca-8286-401c1b28f66d.png">
