### PR TITLE
Add more customization to LbcPrintRule

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### LbcAndroidTest
+- Add params `deleteOnSuccess` and `appendTimestamp` to `LbcPrintRule`
 
 ## 1.1.0
 

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -35,7 +35,7 @@ object AndroidConfig {
 
     const val LBC_CORE_VERSION: String = "1.1.0"
     const val LBC_FOUNDATION_VERSION: String = "1.1.0"
-    const val LBC_ANDROID_TEST_VERSION: String = "1.1.0"
+    const val LBC_ANDROID_TEST_VERSION: String = "1.2.0"
     const val LBC_ACCESSIBILITY_VERSION: String = "1.5.0"
     const val LBC_THEME_VERSION: String = "1.1.0"
     const val MATERIAL_COLOR_UTILITIES_VERSION: String = "1.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ androidx-test-runner = { module = "androidx.test:runner", version = "1.5.2" }
 ##                                                             ⬆ = "1.6.0-alpha01" }
 ##                                                             ⬆ = "1.6.0-alpha02" }
 ##                                                             ⬆ = "1.6.0-alpha03" }
+##                                                             ⬆ = "1.6.0-alpha04" }
 
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version = "_" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }

--- a/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
+++ b/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
@@ -11,7 +11,11 @@ import java.io.File
 /**
  * Custom rule to print a screenshot from a test.
  */
-class LbcPrintRule(private val appName: String) : TestWatcher() {
+class LbcPrintRule(
+    private val appName: String,
+    private val deleteOnSuccess: Boolean = true,
+    private val addTimestampToPath: Boolean = false,
+) : TestWatcher() {
 
     private lateinit var classFolder: File
 
@@ -27,7 +31,11 @@ class LbcPrintRule(private val appName: String) : TestWatcher() {
         counter = 0
         val publicDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         val screenshotFolder = File(publicDirectory, "lbc_screenshots")
-        val appFolder = File(screenshotFolder, appName)
+        val sb = StringBuilder(appName)
+        if (addTimestampToPath) {
+            sb.append("_${System.currentTimeMillis()}")
+        }
+        val appFolder = File(screenshotFolder, sb.toString())
         val className = d.className.substringAfterLast(".")
         classFolder = File(appFolder, className)
         basePath = File(classFolder, d.methodName).absolutePath
@@ -60,7 +68,9 @@ class LbcPrintRule(private val appName: String) : TestWatcher() {
 
     override fun succeeded(description: Description?) {
         super.succeeded(description)
-        screenshots.forEach(File::delete)
-        classFolder.delete() // try delete (fail if not empty)
+        if (deleteOnSuccess) {
+            screenshots.forEach(File::delete)
+            classFolder.delete() // try delete (fail if not empty)
+        }
     }
 }

--- a/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
+++ b/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
@@ -14,7 +14,7 @@ import java.io.File
 class LbcPrintRule(
     private val appName: String,
     private val deleteOnSuccess: Boolean = true,
-    private val addTimestampToPath: Boolean = false,
+    private val appendTimestamp: Boolean = false,
 ) : TestWatcher() {
 
     private lateinit var classFolder: File
@@ -32,7 +32,7 @@ class LbcPrintRule(
         val publicDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         val screenshotFolder = File(publicDirectory, "lbc_screenshots")
         val sb = StringBuilder(appName)
-        if (addTimestampToPath) {
+        if (appendTimestamp) {
             sb.append("_${System.currentTimeMillis()}")
         }
         val appFolder = File(screenshotFolder, sb.toString())

--- a/versions.properties
+++ b/versions.properties
@@ -45,6 +45,8 @@ plugin.android=8.1.1
 ## # available=8.2.0-alpha14
 ## # available=8.2.0-alpha15
 ## # available=8.2.0-alpha16
+## # available=8.2.0-beta01
+## # available=8.3.0-alpha01
 
 plugin.io.gitlab.arturbosch.detekt=1.23.1
 
@@ -57,6 +59,7 @@ version.androidx.activity=1.7.2
 ##            # available=1.8.0-alpha04
 ##            # available=1.8.0-alpha05
 ##            # available=1.8.0-alpha06
+##            # available=1.8.0-alpha07
 
 version.androidx.appcompat=1.6.1
 ##             # available=1.7.0-alpha01
@@ -65,7 +68,7 @@ version.androidx.appcompat=1.6.1
 
 version.androidx.compose=2023.08.00
 
-version.androidx.compose.compiler=1.5.1
+version.androidx.compose.compiler=1.5.2
 
 version.androidx.core=1.10.1
 ##        # available=1.11.0-alpha01
@@ -81,14 +84,16 @@ version.androidx.core=1.10.1
 ##        # available=1.12.0-beta01
 ##        # available=1.12.0-rc01
 
-version.androidx.navigation=2.7.0
+version.androidx.navigation=2.7.1
 
 version.google.accompanist=0.32.0
 ##             # available=0.33.0-alpha
+##             # available=0.33.1-alpha
 
 version.junit.junit=4.13.2
 
 version.kotlin=1.9.0
+## # available=1.9.10
 
 version.google.android.material=1.9.0
 ##                  # available=1.10.0-alpha01


### PR DESCRIPTION
## 📜 Description
- Add `deleteOnSuccess` param
- Add `appendTimestamp` param

## 💡 Motivation and Context
- deleteOnSuccess -> allow to delete (default) or not screenshots if the test succeed.
- appendTimestamp -> append the current timestamp so the directory become unique. It can help locally for debugging because of "ghost" file (file deleted but not really = could not be override)

## 💚 How did you test it?
- locally in oS

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
