### PR TITLE
Add failure

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Allow client to choose between internal or public storage for `LbcPrintRule`
 - Rework `LbcPrintRule` constructor with `internalStorage` and `publicStorage` factories
 - Catch `AssertionError` in print helper in case of error due to multiple root. Fallback to print whole screen
+- Add a whole screen screenshot in `LbcComposeTest::invoke` on failure to get the last state of the app
 
 ## 1.1.0
 

--- a/app/src/androidTest/java/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
+++ b/app/src/androidTest/java/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
@@ -40,7 +40,7 @@ class PrintRuleDemoTest : LbcComposeTest() {
         val files = parentFile.listFiles()!!
         assertEquals(1, files.size)
         assertEquals(
-            File(context.cacheDir, "screenshot/PrintRuleDemoTest/print_screenshot_on_failure_test_0_TIMEOUT.jpeg").absolutePath,
+            File(context.cacheDir, "screenshot/PrintRuleDemoTest/print_screenshot_on_timeout_test_0_TIMEOUT.jpeg").absolutePath,
             files.first().absolutePath,
         )
 

--- a/app/src/androidTest/java/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
+++ b/app/src/androidTest/java/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
@@ -19,7 +19,7 @@ import kotlin.time.Duration.Companion.milliseconds
 class PrintRuleDemoTest : LbcComposeTest() {
 
     @Test
-    fun print_screenshot_on_failure_test(): Unit = invoke {
+    fun print_screenshot_on_timeout_test(): Unit = invoke {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
 
         setContent {
@@ -46,4 +46,24 @@ class PrintRuleDemoTest : LbcComposeTest() {
 
         // assert(false) // Make the test fail to check if screenshots still exist in device cache storage
     }
+
+    /**
+     * Screenshot on failure testing (manual testing)
+     */
+    //    @Test
+    //    fun print_screenshot_on_failure_test(): Unit = invoke {
+    //        setContent {
+    //            Box(
+    //                modifier = Modifier
+    //                    .fillMaxSize()
+    //                    .background(Brush.verticalGradient(listOf(Color.Red, Color.Blue))),
+    //            ) {
+    //                Text(text = "my text")
+    //            }
+    //        }
+    //
+    //        hasText("not my text")
+    //            .waitUntilExactlyOneExists(this)
+    //            .assertIsDisplayed()
+    //    }
 }

--- a/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/LbcAndroidTestConstants.kt
+++ b/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/LbcAndroidTestConstants.kt
@@ -24,9 +24,24 @@ package studio.lunabee.compose.androidtest
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-internal object LbcAndroidTestConstants {
+object LbcAndroidTestConstants {
     /**
      * Default timeout used for waiting methods in a [androidx.compose.ui.test.ComposeUiTest] scope.
      */
     val WaitNodeTimeout: Duration = 5.seconds
+
+    /**
+     * Suffix for timeout screenshot on waiting composable
+     */
+    const val TimeoutSuffix: String = "_TIMEOUT"
+
+    /**
+     * Suffix for exception throws on waiting composable
+     */
+    const val ErrorSuffix: String = "_ERROR"
+
+    /**
+     * Suffix for any failure at the end of test
+     */
+    const val FailureSuffix: String = "_FAILURE"
 }

--- a/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/LbcComposeTest.kt
+++ b/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/LbcComposeTest.kt
@@ -63,7 +63,15 @@ abstract class LbcComposeTest {
         effectContext: CoroutineContext = EmptyCoroutineContext,
         block: ComposeUiTest.() -> Unit,
     ) {
-        runComposeUiTest(effectContext = effectContext, block = block)
+        runComposeUiTest(effectContext = effectContext) {
+            try {
+                block()
+            } catch (e: Throwable) {
+                val suffix = LbcAndroidTestConstants.FailureSuffix + "_${e.javaClass.simpleName}"
+                printRule.printWholeScreen(suffix)
+                throw e
+            }
+        }
     }
 
     /**
@@ -79,7 +87,14 @@ abstract class LbcComposeTest {
         runAndroidComposeUiTest(
             activityClass = clazz,
             effectContext = effectContext,
-            block = block,
-        )
+        ) {
+            try {
+                block()
+            } catch (e: Throwable) {
+                val suffix = LbcAndroidTestConstants.FailureSuffix + "_${e.javaClass.simpleName}"
+                printRule.printWholeScreen(suffix)
+                throw e
+            }
+        }
     }
 }

--- a/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
+++ b/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
@@ -128,7 +128,7 @@ fun SemanticsMatcher.waitUntilAtLeastOneExists(
  * Wait for the [SemanticsNodeInteraction] corresponding to the provided [SemanticsMatcher] and return it condition is filled
  * (i.e element exists).
  * Before returning the element, a screenshot of the root node is taken. If the condition is not filled, a screenshot is also
- * taken with the suffix "_TIMEOUT" to see what went wrong.
+ * taken with the suffix "LbcAndroidTestConstants.timeoutSuffix" to see what went wrong.
  *
  * ⚠️ It doesn't mean that all elements are displayed. You should check the visibility with
  * [androidx.compose.ui.test.assertIsDisplayed].
@@ -154,10 +154,10 @@ fun SemanticsMatcher.waitAndPrintRootToCacheDir(
         composeUiTest.onNode(this)
     } catch (e: ComposeTimeoutException) {
         composeUiTest.onRoot(useUnmergedTree = useUnmergedTree)
-            .printToCacheDir(printRule, "${suffix}_TIMEOUT")
+            .printToCacheDir(printRule, "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
         throw e
     } catch (e: AssertionError) {
-        printRule.printWholeScreen(suffix = "${suffix}_ERROR")
+        printRule.printWholeScreen(suffix = "${suffix}${LbcAndroidTestConstants.ErrorSuffix}")
         throw e
     }
 }
@@ -166,7 +166,7 @@ fun SemanticsMatcher.waitAndPrintRootToCacheDir(
  * Wait for the [SemanticsNodeInteraction] corresponding to the provided [SemanticsMatcher] and return it condition is filled
  * (i.e element exists).
  * Before returning the element, a screenshot of the whole screen is taken. If the condition is not filled, a screenshot is also
- * taken with the suffix "_TIMEOUT" to see what went wrong.
+ * taken with the suffix [LbcAndroidTestConstants.TimeoutSuffix] to see what went wrong.
  *
  * Should be use when the UI contains many root node, like when a dialog is shown. In other cases, [waitAndPrintRootToCacheDir] must be
  * preferred.
@@ -193,7 +193,7 @@ fun SemanticsMatcher.waitAndPrintWholeScreenToCacheDir(
         printRule.printWholeScreen(suffix = suffix)
         composeUiTest.onAllNodes(this).filterToOne(this)
     } catch (e: ComposeTimeoutException) {
-        printRule.printWholeScreen(suffix = "${suffix}_TIMEOUT")
+        printRule.printWholeScreen(suffix = "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
         throw e
     }
 }


### PR DESCRIPTION
## 📜 Description
- Wrap test block in a try catch which take a screenshot on every error with `_FAILURE_<exception_class_name>` suffix
- Extract suffixes to constants

## 💡 Motivation and Context
- Give more information about the failing test, even if extension `waitAndPrintRootToCacheDir` was not used

## 💚 How did you test it?
- Uncomment `print_screenshot_on_failure_test` test and check the screenshot manually

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
<img width="2727" alt="image" src="https://github.com/LunabeeStudio/Lunabee-Compose-Android/assets/45555889/64515c5e-0760-459e-8765-0126b5384a52">
