### PR TITLE
Use context receiver to pass ComposeUiTest

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Rework `LbcPrintRule` constructor with `internalStorage` and `publicStorage` factories
 - Catch `AssertionError` in print helper in case of error due to multiple root. Fallback to print whole screen
 - Add a whole screen screenshot in `LbcComposeTest::invoke` on failure to get the last state of the app
+- Use context receiver for `ComposeUiTest` on matcher extension
 
 ## 1.1.0
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,8 @@ android {
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
     }
+
+    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
 }
 
 dependencies {

--- a/app/src/androidTest/java/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
+++ b/app/src/androidTest/java/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
@@ -28,7 +28,7 @@ class PrintRuleDemoTest : LbcComposeTest() {
 
         val error = runCatching {
             hasText("bar")
-                .waitAndPrintRootToCacheDir(this, printRule, timeout = 200.milliseconds)
+                .waitAndPrintRootToCacheDir(printRule, timeout = 200.milliseconds)
                 .assertIsDisplayed()
         }.exceptionOrNull()
         assertIs<ComposeTimeoutException>(error)

--- a/app/src/androidTest/java/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
+++ b/app/src/androidTest/java/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
@@ -63,7 +63,7 @@ class PrintRuleDemoTest : LbcComposeTest() {
     //        }
     //
     //        hasText("not my text")
-    //            .waitUntilExactlyOneExists(this)
+    //            .waitUntilExactlyOneExists()
     //            .assertIsDisplayed()
     //    }
 }

--- a/lbcandroidtest/build.gradle.kts
+++ b/lbcandroidtest/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
 android {
     resourcePrefix("lbc_at_")
     namespace = "studio.lunabee.compose.androidtest"
+
+    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
 }
 
 description = "Tools for developping android test"

--- a/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
+++ b/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
@@ -28,15 +28,15 @@ import kotlin.time.Duration
  *     .waitUntilDoesNotExist(this, false, 1.seconds)
  * ```
  */
+context(ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitUntilDoesNotExist(
-    composeUiTest: ComposeUiTest,
     useUnmergedTree: Boolean = false,
     timeout: Duration = LbcAndroidTestConstants.WaitNodeTimeout,
 ): SemanticsNodeInteraction {
     // Method copy from ComposeUiTest.waitUntilExactlyOneExists to add useUnmergedTree.
     // Waiting for answer: https://issuetracker.google.com/issues/268432145
-    return waitUntilNodeCount(composeUiTest, 0, useUnmergedTree, timeout).filterToOne(this)
+    return waitUntilNodeCount(0, useUnmergedTree, timeout).filterToOne(this)
 }
 
 /**
@@ -54,15 +54,15 @@ fun SemanticsMatcher.waitUntilDoesNotExist(
  *     .assertIdDisplayed() // additional check
  * ```
  */
+context(ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitUntilExactlyOneExists(
-    composeUiTest: ComposeUiTest,
     useUnmergedTree: Boolean = false,
     timeout: Duration = LbcAndroidTestConstants.WaitNodeTimeout,
 ): SemanticsNodeInteraction {
     // Method copy from ComposeUiTest.waitUntilExactlyOneExists to add useUnmergedTree.
     // Waiting for answer: https://issuetracker.google.com/issues/268432145
-    return waitUntilNodeCount(composeUiTest, 1, useUnmergedTree, timeout).filterToOne(this)
+    return waitUntilNodeCount(1, useUnmergedTree, timeout).filterToOne(this)
 }
 
 /**
@@ -80,19 +80,19 @@ fun SemanticsMatcher.waitUntilExactlyOneExists(
  *     .assertIdDisplayed() // additional check
  * ```
  */
+context(ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitUntilNodeCount(
-    composeUiTest: ComposeUiTest,
     count: Int,
     useUnmergedTree: Boolean = false,
     timeout: Duration = LbcAndroidTestConstants.WaitNodeTimeout,
 ): SemanticsNodeInteractionCollection {
     // Method copy from ComposeUiTest.waitUntilExactlyOneExists to add useUnmergedTree.
     // Waiting for answer: https://issuetracker.google.com/issues/268432145
-    composeUiTest.waitUntil(timeout.inWholeMilliseconds) {
-        composeUiTest.onAllNodes(this, useUnmergedTree).fetchSemanticsNodes().size == count
+    waitUntil(timeout.inWholeMilliseconds) {
+        onAllNodes(this, useUnmergedTree).fetchSemanticsNodes().size == count
     }
-    return composeUiTest.onAllNodes(this, useUnmergedTree)
+    return onAllNodes(this, useUnmergedTree)
 }
 
 /**
@@ -140,20 +140,20 @@ fun SemanticsMatcher.waitUntilAtLeastOneExists(
  *     .performClick() // additional check
  * ```
  */
+context(ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitAndPrintRootToCacheDir(
-    composeUiTest: ComposeUiTest,
     printRule: LbcPrintRule,
     suffix: String = "",
     useUnmergedTree: Boolean = false,
     timeout: Duration = LbcAndroidTestConstants.WaitNodeTimeout,
 ): SemanticsNodeInteraction {
     return try {
-        waitUntilExactlyOneExists(composeUiTest, useUnmergedTree, timeout)
-        composeUiTest.onRoot().printToCacheDir(printRule, suffix)
-        composeUiTest.onNode(this)
+        waitUntilExactlyOneExists(useUnmergedTree, timeout)
+        onRoot().printToCacheDir(printRule, suffix)
+        onNode(this)
     } catch (e: ComposeTimeoutException) {
-        composeUiTest.onRoot(useUnmergedTree = useUnmergedTree)
+        onRoot(useUnmergedTree = useUnmergedTree)
             .printToCacheDir(printRule, "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
         throw e
     } catch (e: AssertionError) {

--- a/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
+++ b/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
@@ -110,18 +110,18 @@ fun SemanticsMatcher.waitUntilNodeCount(
  *     .assertIdDisplayed() // additional check
  * ```
  */
+context(ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitUntilAtLeastOneExists(
-    composeUiTest: ComposeUiTest,
     useUnmergedTree: Boolean = false,
     timeout: Duration = LbcAndroidTestConstants.WaitNodeTimeout,
 ): SemanticsNodeInteractionCollection {
     // Method copy from ComposeUiTest.waitUntilExactlyOneExists to add useUnmergedTree.
     // Waiting for answer: https://issuetracker.google.com/issues/268432145
-    composeUiTest.waitUntil(timeout.inWholeMilliseconds) {
-        composeUiTest.onAllNodes(this, useUnmergedTree).fetchSemanticsNodes().isNotEmpty()
+    waitUntil(timeout.inWholeMilliseconds) {
+        onAllNodes(this, useUnmergedTree).fetchSemanticsNodes().isNotEmpty()
     }
-    return composeUiTest.onAllNodes(this, useUnmergedTree)
+    return onAllNodes(this, useUnmergedTree)
 }
 
 /**
@@ -180,18 +180,18 @@ fun SemanticsMatcher.waitAndPrintRootToCacheDir(
  *     .waitAndPrintWholeScreenToCacheDir(composeUiTest, printRule, "_suffix", false, 1.seconds)
  * ```
  */
+context(ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitAndPrintWholeScreenToCacheDir(
-    composeUiTest: ComposeUiTest,
     printRule: LbcPrintRule,
     suffix: String = "",
     useUnmergedTree: Boolean = false,
     timeout: Duration = LbcAndroidTestConstants.WaitNodeTimeout,
 ): SemanticsNodeInteraction {
     return try {
-        waitUntilAtLeastOneExists(composeUiTest, useUnmergedTree, timeout)
+        waitUntilAtLeastOneExists(useUnmergedTree, timeout)
         printRule.printWholeScreen(suffix = suffix)
-        composeUiTest.onAllNodes(this).filterToOne(this)
+        onAllNodes(this).filterToOne(this)
     } catch (e: ComposeTimeoutException) {
         printRule.printWholeScreen(suffix = "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
         throw e


### PR DESCRIPTION
## 📜 Description
- Use context receiver to get the `ComposeUiTest`

## 💡 Motivation and Context
- `invoke` always provide the `ComposeUiTest` so we don't need to pass it in every matcher

## 💚 How did you test it?
- run test

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
