### PR TITLE
feature/fix_onFailure_fails

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,8 +26,9 @@ android-gradle-plugin = "8.2.0-rc03"
 ##                 ⬆ = "8.3.0-alpha11"
 ##                 ⬆ = "8.3.0-alpha12"
 ##                 ⬆ = "8.3.0-alpha13"
+##                 ⬆ = "8.3.0-alpha14"
 
-detekt = "1.23.3"
+detekt = "1.23.4"
 
 androidx-test-runner = "1.5.2"
 ##                ⬆ = "1.5.3-alpha01"
@@ -50,6 +51,8 @@ google-android-material = "1.10.0"
 ##                   ⬆ = "1.11.0-alpha02"
 ##                   ⬆ = "1.11.0-alpha03"
 ##                   ⬆ = "1.11.0-beta01"
+##                   ⬆ = "1.11.0-rc01"
+##                   ⬆ = "1.12.0-alpha01"
 
 androidx-appcompat = "1.6.1"
 ##              ⬆ = "1.7.0-alpha01"
@@ -59,7 +62,7 @@ androidx-appcompat = "1.6.1"
 androidx-core = "1.12.0"
 ##         ⬆ = "1.13.0-alpha01"
 
-androidx-activity = "1.8.0"
+androidx-activity = "1.8.1"
 
 androidx-navigation = "2.7.5"
 

--- a/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/LbcComposeTest.kt
+++ b/lbcandroidtest/src/main/java/studio/lunabee/compose/androidtest/LbcComposeTest.kt
@@ -72,7 +72,7 @@ abstract class LbcComposeTest {
             try {
                 block()
             } catch (e: Throwable) {
-                onFailure(e)
+                runCatching { onFailure(e) }
                 throw e
             }
         }
@@ -95,7 +95,7 @@ abstract class LbcComposeTest {
             try {
                 block()
             } catch (e: Throwable) {
-                onFailure(e)
+                runCatching { onFailure(e) }
                 throw e
             }
         }


### PR DESCRIPTION
## 📜 Description
- Wrap `LbcComposeTest::onFailure` call into `runCatching` to ignore error and make sure we re-throw the original error

## 💡 Motivation and Context
- On compose failure, the `onFailure` function might also failed (`java.lang.IllegalStateException: No compose hierarchies found in the app.`) and hides the original error

## 💚 How did you test it?

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [ ] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
